### PR TITLE
Add ssh key to buildtex action

### DIFF
--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ssh-key: ${{ secrets.ACTION_BOT }}
           fetch-depth: 0
       - name: Get changed LaTeX files
         id: latex-files


### PR DESCRIPTION
# [No Issue]

Following [this solution](https://stackoverflow.com/a/76135647), I added deploy keys to try to fix the branch protection github actions problem.

After this is merged, I will re-enable the protection rules