### PR TITLE
Revert github action ssh key

### DIFF
--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.ACTION_BOT }}
           fetch-depth: 0
       - name: Get changed LaTeX files
         id: latex-files


### PR DESCRIPTION
# #[None]

## Description
Revert ssh key. Its causing the action to fail and I dont want to block the pipeline. I might look into fixing it again later.