### PR TITLE
441: Add vnv report automated testing info

### DIFF
--- a/docs/VnVReport/VnVReport.tex
+++ b/docs/VnVReport/VnVReport.tex
@@ -178,6 +178,19 @@ should be highlighted.}
 
 \section{Automated Testing}
 
+As outlined in the VnV Plan, we implemented automated testing using the
+\texttt{Jest} framework. We also projected the use of \texttt{Playwright} in the
+original plan, but as of this report, we have not used it for any testing. Due
+to the rapid development and changes made to the app, we have not invested the
+time to create end-to-end tests at this point that may be more brittle than
+unit tests and slow down development speed. Additionally, usage/integration of
+\texttt{Coveralls} was discussed in the plan, but has not been added at this
+point due to time constraints and its relatively low priority. We have been
+able to use Jest to check code coverage.
+
+
+Automated tests are run via GitHub Actions and run on every new PR.
+
 \section{Trace to Requirements}
 
 \section{Trace to Modules}


### PR DESCRIPTION
# #441

## Description
Adds info for the vnv report automated testing section

<img width="740" height="783" alt="image" src="https://github.com/user-attachments/assets/1782ad61-169d-45a1-a392-450d935abcff" />
