### PR TITLE
444 Unit tests General Items

### DIFF
--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -1013,13 +1013,11 @@ The unit tests focuses on modules that implement the core logic of Flow, particu
 responsible for command interpretation, geometry manipulation, and history management. These 
 components were prioritized because they directly affect the application of user operations 
 and the internal state of the system. Unit tests therefore verify functionality within the 
-File Interface Module (M3), which will handle file operations such as importing pdf files, 
-Commands Parser Module (M6), Mode Commands Module (M7), Text Buffer Module (M10), 
-Geometry State Module (M11), Geometry State Mutator Module (M12), and Undo Redo Module (M13).
-The tests target representative behaviors such as parsing multi-key commands, switching 
-modes, manipulating selected shapes (e.g., translating or deleting objects), creating and 
-positioning diagram elements such as arrows and squares, and performing undo and redo 
-operations.
+Commands Parser Module (M6), Geometry State Module (M11), Geometry State Mutator Module 
+(M12), and Undo Redo Module (M13). The tests target representative behaviors such as 
+parsing multi-key commands, switching modes, manipulating selected shapes (e.g., 
+translating or deleting objects), creating and positioning diagram elements such as 
+arrows and squares, and performing undo and redo operations.
 
 Some modules are not tested in isolation but are exercised indirectly through these tests. 
 For example, the Shape Interface Module (M8) and Geometry State Parser Module (M4) are 
@@ -1029,8 +1027,9 @@ behavior is verified through tests that manipulate geometry or execute commands 
 through standalone unit tests.
 
 Several modules were excluded from the unit testing scope because their functionality has
-not yet been implemented. These include the Geometry State Converter Module (M5), which 
-will convert between internal geometry representations and external formats, the User 
+not yet been implemented. These include the File Interface Module (M3), which will 
+handle file operations such as importing pdf files, Geometry State Converter Module (M5), 
+which will convert between internal geometry representations and external formats, the User 
 Preference Module (M9), which is intended to store configurable user settings, and the 
 User Persistence Module (M14), which will manage saving and restoring user state 
 between sessions.


### PR DESCRIPTION
# #444 

## Description
This pr brings forward which modules are tested using the unit tests. From this, we will be able to place each of the unit tests we made into respective modules and later on report on the tests in the vnvreport.

The scope paragraphs talk about which modules are being tested and which modules are left out, and why. Feel free to suggest changes for those.

I think with all the unit tests we made, we should be able to place at least one test into one of the sections for the modules I listed out. Again let me know if you think otherwise.